### PR TITLE
added for support 491x and 51xx boards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,21 @@ LDSCRIPT_McciBootloader_4801	:=	$(BOOTLOADER_LDSCRIPT_ABZ)
 
 ##############################################################################
 #
+#	The 491x bootloader
+#
+##############################################################################
+
+BOOTLOADERS += McciBootloader_491x
+
+LIBS_McciBootloader_491x :=				\
+	${BOOTLOADER_LIBS_ABZ}				\
+	${T_OBJDIR}/libmcci_bootloader_catena491x.a	\
+### end LIBS_McciBootloader_491x
+
+LDSCRIPT_McciBootloader_491x	:=	$(BOOTLOADER_LDSCRIPT_ABZ)
+
+##############################################################################
+#
 #	The 46xx bootloader
 #
 ##############################################################################
@@ -96,6 +111,21 @@ LIBS_McciBootloader_46xx :=				\
 ### end LIBS_McciBootloader_46xx
 
 LDSCRIPT_McciBootloader_46xx	:=	$(BOOTLOADER_LDSCRIPT_ABZ)
+
+##############################################################################
+#
+#	The 51xx bootloader
+#
+##############################################################################
+
+BOOTLOADERS += McciBootloader_51xx
+
+LIBS_McciBootloader_51xx :=				\
+	${BOOTLOADER_LIBS_ABZ}				\
+	${T_OBJDIR}/libmcci_bootloader_catena51xx.a	\
+### end LIBS_McciBootloader_51xx
+
+LDSCRIPT_McciBootloader_51xx	:=	$(BOOTLOADER_LDSCRIPT_ABZ)
 
 ##############################################################################
 #
@@ -217,6 +247,29 @@ SOURCES_libmcci_bootloader_catena4801 :=				\
 
 ##############################################################################
 #
+#	The catena491x library
+#
+##############################################################################
+
+LIBRARIES += libmcci_bootloader_catena491x
+
+_ := platform/board/mcci/catena491x
+
+CFLAGS_OPT_libmcci_bootloader_catena491x += -Os
+
+INCLUDES_libmcci_bootloader_catena491x :=				\
+	$(INCLUDES_libmcci_bootloader_catena_abz)			\
+	platform/driver/flash_mx25v8035f/i				\
+	$_/i								\
+# end INCLUDES_libmcci_bootloader_catena491x
+
+SOURCES_libmcci_bootloader_catena491x :=				\
+	$_/src/mccibootloaderboard_catena491x_platforminterface.c	\
+	$_/src/mccibootloaderboard_catena491x_storageinit.c		\
+# end SOURCES_libmcci_bootloader_catena491x
+
+##############################################################################
+#
 #	The catena46xx library
 #
 ##############################################################################
@@ -237,6 +290,29 @@ SOURCES_libmcci_bootloader_catena46xx :=				\
 	$_/src/mccibootloaderboard_catena46xx_platforminterface.c	\
 	$_/src/mccibootloaderboard_catena46xx_storageinit.c		\
 # end SOURCES_libmcci_bootloader_catena46xx
+
+##############################################################################
+#
+#	The catena51xx library
+#
+##############################################################################
+
+LIBRARIES += libmcci_bootloader_catena51xx
+
+_ := platform/board/mcci/catena51xx
+
+CFLAGS_OPT_libmcci_bootloader_catena51xx += -Os
+
+INCLUDES_libmcci_bootloader_catena51xx :=				\
+	$(INCLUDES_libmcci_bootloader_catena_abz)			\
+	platform/driver/flash_mx25v8035f/i				\
+	$_/i								\
+# end INCLUDES_libmcci_bootloader_catena51xx
+
+SOURCES_libmcci_bootloader_catena51xx :=				\
+	$_/src/mccibootloaderboard_catena51xx_platforminterface.c	\
+	$_/src/mccibootloaderboard_catena51xx_storageinit.c		\
+# end SOURCES_libmcci_bootloader_catena51xx
 
 ##############################################################################
 #

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ BOOTLOADERS += McciBootloader_491x
 
 LIBS_McciBootloader_491x :=				\
 	${BOOTLOADER_LIBS_ABZ}				\
-	${T_OBJDIR}/libmcci_bootloader_catena491x.a	\
+	${T_OBJDIR}/libmcci_bootloader_model491x.a	\
 ### end LIBS_McciBootloader_491x
 
 LDSCRIPT_McciBootloader_491x	:=	$(BOOTLOADER_LDSCRIPT_ABZ)
@@ -247,26 +247,26 @@ SOURCES_libmcci_bootloader_catena4801 :=				\
 
 ##############################################################################
 #
-#	The catena491x library
+#	The model491x library
 #
 ##############################################################################
 
-LIBRARIES += libmcci_bootloader_catena491x
+LIBRARIES += libmcci_bootloader_model491x
 
-_ := platform/board/mcci/catena491x
+_ := platform/board/mcci/model491x
 
-CFLAGS_OPT_libmcci_bootloader_catena491x += -Os
+CFLAGS_OPT_libmcci_bootloader_model491x += -Os
 
-INCLUDES_libmcci_bootloader_catena491x :=				\
+INCLUDES_libmcci_bootloader_model491x :=				\
 	$(INCLUDES_libmcci_bootloader_catena_abz)			\
 	platform/driver/flash_mx25v8035f/i				\
 	$_/i								\
-# end INCLUDES_libmcci_bootloader_catena491x
+# end INCLUDES_libmcci_bootloader_model491x
 
-SOURCES_libmcci_bootloader_catena491x :=				\
-	$_/src/mccibootloaderboard_catena491x_platforminterface.c	\
-	$_/src/mccibootloaderboard_catena491x_storageinit.c		\
-# end SOURCES_libmcci_bootloader_catena491x
+SOURCES_libmcci_bootloader_model491x :=				\
+	$_/src/mccibootloaderboard_model491x_platforminterface.c	\
+	$_/src/mccibootloaderboard_model491x_storageinit.c		\
+# end SOURCES_libmcci_bootloader_model491x
 
 ##############################################################################
 #

--- a/platform/board/mcci/catena51xx/i/mcci_bootloader_board_catena51xx.h
+++ b/platform/board/mcci/catena51xx/i/mcci_bootloader_board_catena51xx.h
@@ -1,0 +1,37 @@
+/*
+
+Module:	mcci_bootloader_board_catena51xx.h
+
+Function:
+	Definitions for bootloader on MCCI Catena 51xx.
+
+Copyright and License:
+	This file copyright (C) 2021 by
+
+		MCCI Corporation
+		3520 Krums Corners Road
+		Ithaca, NY  14850
+
+	See accompanying LICENSE file for copyright and license information.
+
+Author:
+	Terry Moore, MCCI Corporation	March 2021
+
+*/
+
+#ifndef _mcci_bootloader_board_catena51xx_h_
+#define _mcci_bootloader_board_catena51xx_h_	/* prevent multiple includes */
+
+#pragma once
+
+#include "mcci_bootloader_platform.h"
+#include "mcci_bootloader_board_catena_abz.h"
+
+MCCI_BOOTLOADER_BEGIN_DECLS
+
+McciBootloaderPlatform_StorageInitFn_t
+McciBootloaderBoard_Catena51xx_storageInit;
+
+MCCI_BOOTLOADER_END_DECLS
+
+#endif /* _mcci_bootloader_board_catena51xx_h_ */

--- a/platform/board/mcci/catena51xx/i/mcci_bootloader_board_catena51xx.h
+++ b/platform/board/mcci/catena51xx/i/mcci_bootloader_board_catena51xx.h
@@ -6,7 +6,7 @@ Function:
 	Definitions for bootloader on MCCI Catena 51xx.
 
 Copyright and License:
-	This file copyright (C) 2021 by
+	This file copyright (C) 2023 by
 
 		MCCI Corporation
 		3520 Krums Corners Road
@@ -15,7 +15,7 @@ Copyright and License:
 	See accompanying LICENSE file for copyright and license information.
 
 Author:
-	Terry Moore, MCCI Corporation	March 2021
+	Dhinesh Kumar Pitchai, MCCI Corporation	October 2023
 
 */
 

--- a/platform/board/mcci/catena51xx/src/mccibootloaderboard_catena51xx_platforminterface.c
+++ b/platform/board/mcci/catena51xx/src/mccibootloaderboard_catena51xx_platforminterface.c
@@ -1,0 +1,78 @@
+/*
+
+Module:	mccibootloaderboard_catena51xx_platforminterface.c
+
+Function:
+	gk_McciBootloaderPlatformInterface for MCCI Catena 51xx boards.
+
+Copyright and License:
+	This file copyright (C) 2021 by
+
+		MCCI Corporation
+		3520 Krums Corners Road
+		Ithaca, NY  14850
+
+	See accompanying LICENSE file for copyright and license information.
+
+Author:
+	Terry Moore, MCCI Corporation	March 2021
+
+*/
+
+#include "mcci_bootloader_board_catena51xx.h"
+
+#include "mcci_bootloader_flash_mx25v8035f.h"
+
+/****************************************************************************\
+|
+|	Manifest constants & typedefs.
+|
+\****************************************************************************/
+
+
+
+/****************************************************************************\
+|
+|	Read-only data.
+|
+\****************************************************************************/
+
+const McciBootloaderPlatform_Interface_t
+gk_McciBootloaderPlatformInterface =
+	{
+	.pSystemInit = McciBootloaderBoard_CatenaAbz_systemInit,
+	.pPrepareForLaunch = McciBootloaderBoard_CatenaAbz_prepareForLaunch,
+	.pFail = McciBootloaderBoard_CatenaAbz_fail,
+	.pDelayMs = McciBootloaderBoard_CatenaAbz_delayMs,
+	.pGetUpdate = McciBootloaderBoard_CatenaAbz_getUpdate,
+	.pSetUpdate = McciBootloaderBoard_CatenaAbz_setUpdate,
+	.pSystemFlashErase = McciBootloader_Stm32L0_systemFlashErase,
+	.pSystemFlashWrite = McciBootloader_Stm32L0_systemFlashWrite,
+	.Storage =
+		{
+		.pInit = McciBootloaderBoard_Catena51xx_storageInit,
+		.pRead = McciBootloaderFlash_Mx25v8035f_storageRead,
+		.pGetPrimaryAddress = McciBootloaderBoard_CatenaAbz_getPrimaryStorageAddress,
+		.pGetFallbackAddress = McciBootloaderBoard_CatenaAbz_getFallbackStorageAddress,
+		},
+	.Spi =
+		{
+		.pInit = McciBootloaderBoard_CatenaAbz_spiInit,
+		.pTransfer = McciBootloaderBoard_CatenaAbz_spiTransfer,
+		},
+	.Annunciator =
+		{
+		.pInit = McciBootloaderBoard_CatenaAbz_annunciatorInit,
+		.pIndicateState = McciBootloaderBoard_CatenaAbz_annunciatorIndicateState,
+		},
+	};
+
+/****************************************************************************\
+|
+|	Variables.
+|
+\****************************************************************************/
+
+
+
+/**** end of mccibootloaderboard_catenaabz_platforminterface.c ****/

--- a/platform/board/mcci/catena51xx/src/mccibootloaderboard_catena51xx_platforminterface.c
+++ b/platform/board/mcci/catena51xx/src/mccibootloaderboard_catena51xx_platforminterface.c
@@ -6,7 +6,7 @@ Function:
 	gk_McciBootloaderPlatformInterface for MCCI Catena 51xx boards.
 
 Copyright and License:
-	This file copyright (C) 2021 by
+	This file copyright (C) 2023 by
 
 		MCCI Corporation
 		3520 Krums Corners Road
@@ -15,7 +15,7 @@ Copyright and License:
 	See accompanying LICENSE file for copyright and license information.
 
 Author:
-	Terry Moore, MCCI Corporation	March 2021
+	Dhinesh Kumar Pitchai, MCCI Corporation	October 2023
 
 */
 

--- a/platform/board/mcci/catena51xx/src/mccibootloaderboard_catena51xx_platforminterface.c
+++ b/platform/board/mcci/catena51xx/src/mccibootloaderboard_catena51xx_platforminterface.c
@@ -75,4 +75,4 @@ gk_McciBootloaderPlatformInterface =
 
 
 
-/**** end of mccibootloaderboard_catenaabz_platforminterface.c ****/
+/**** end of mccibootloaderboard_catena51xx_platforminterface.c ****/

--- a/platform/board/mcci/catena51xx/src/mccibootloaderboard_catena51xx_storageinit.c
+++ b/platform/board/mcci/catena51xx/src/mccibootloaderboard_catena51xx_storageinit.c
@@ -6,7 +6,7 @@ Function:
 	McciBootloaderBoard_Catena51xx_storageInit()
 
 Copyright and License:
-	This file copyright (C) 2021 by
+	This file copyright (C) 2023 by
 
 		MCCI Corporation
 		3520 Krums Corners Road
@@ -15,7 +15,7 @@ Copyright and License:
 	See accompanying LICENSE file for copyright and license information.
 
 Author:
-	Terry Moore, MCCI Corporation	March 2021
+	Dhinesh Kumar Pitchai, MCCI Corporation	October 2023
 
 */
 

--- a/platform/board/mcci/catena51xx/src/mccibootloaderboard_catena51xx_storageinit.c
+++ b/platform/board/mcci/catena51xx/src/mccibootloaderboard_catena51xx_storageinit.c
@@ -1,0 +1,85 @@
+/*
+
+Module:	mccibootloaderboard_catena51xx_storageinit.c
+
+Function:
+	McciBootloaderBoard_Catena51xx_storageInit()
+
+Copyright and License:
+	This file copyright (C) 2021 by
+
+		MCCI Corporation
+		3520 Krums Corners Road
+		Ithaca, NY  14850
+
+	See accompanying LICENSE file for copyright and license information.
+
+Author:
+	Terry Moore, MCCI Corporation	March 2021
+
+*/
+
+#include "mcci_bootloader_board_catena51xx.h"
+
+#include "mcci_bootloader_flash_mx25v8035f.h"
+
+/****************************************************************************\
+|
+|	Manifest constants & typedefs.
+|
+\****************************************************************************/
+
+
+
+/****************************************************************************\
+|
+|	Read-only data.
+|
+\****************************************************************************/
+
+
+
+/****************************************************************************\
+|
+|	Variables.
+|
+\****************************************************************************/
+
+
+/*
+
+Name:	McciBootloaderBoard_Catena51xx_storageInit()
+
+Function:
+	Initialize the Catena51xx external storage.
+
+Definition:
+	typedef McciBootloaderPlatform_StorageInit_t
+		McciBootloaderBoard_Catena51xx_storageInit;
+
+	void McciBootloaderBoard_Catena51xx_storageInit(
+		void
+		);
+
+Description:
+	Initialize SPI, init the external flash, and we're ready.
+
+Returns:
+	No explicit result.
+
+Notes:
+
+
+*/
+
+void
+McciBootloaderBoard_Catena51xx_storageInit(
+	void
+	)
+	{
+	McciBootloaderPlatform_spiInit();
+	McciBootloaderFlash_Mx25v8035f_storageInit();
+	}
+
+
+/**** end of mccibootloaderboard_catena51xx_storageinit.c ****/

--- a/platform/board/mcci/model491x/i/mcci_bootloader_board_model491x.h
+++ b/platform/board/mcci/model491x/i/mcci_bootloader_board_model491x.h
@@ -3,10 +3,10 @@
 Module:	mcci_bootloader_board_model491x.h
 
 Function:
-	Definitions for bootloader on MCCI Catena 4801.
+	Definitions for bootloader on MCCI Catena 491x boards.
 
 Copyright and License:
-	This file copyright (C) 2021 by
+	This file copyright (C) 2023 by
 
 		MCCI Corporation
 		3520 Krums Corners Road
@@ -15,7 +15,7 @@ Copyright and License:
 	See accompanying LICENSE file for copyright and license information.
 
 Author:
-	Terry Moore, MCCI Corporation	March 2021
+	Dhinesh Kumar Pitchai, MCCI Corporation	September 2023
 
 */
 

--- a/platform/board/mcci/model491x/i/mcci_bootloader_board_model491x.h
+++ b/platform/board/mcci/model491x/i/mcci_bootloader_board_model491x.h
@@ -1,0 +1,37 @@
+/*
+
+Module:	mcci_bootloader_board_model491x.h
+
+Function:
+	Definitions for bootloader on MCCI Catena 4801.
+
+Copyright and License:
+	This file copyright (C) 2021 by
+
+		MCCI Corporation
+		3520 Krums Corners Road
+		Ithaca, NY  14850
+
+	See accompanying LICENSE file for copyright and license information.
+
+Author:
+	Terry Moore, MCCI Corporation	March 2021
+
+*/
+
+#ifndef _mcci_bootloader_board_model491x_h_
+#define _mcci_bootloader_board_model491x_h_	/* prevent multiple includes */
+
+#pragma once
+
+#include "mcci_bootloader_platform.h"
+#include "mcci_bootloader_board_catena_abz.h"
+
+MCCI_BOOTLOADER_BEGIN_DECLS
+
+McciBootloaderPlatform_StorageInitFn_t
+McciBootloaderBoard_Model491x_storageInit;
+
+MCCI_BOOTLOADER_END_DECLS
+
+#endif /* _mcci_bootloader_board_model491x_h_ */

--- a/platform/board/mcci/model491x/src/mccibootloaderboard_model491x_platforminterface.c
+++ b/platform/board/mcci/model491x/src/mccibootloaderboard_model491x_platforminterface.c
@@ -3,10 +3,10 @@
 Module:	mccibootloaderboard_model491x_platforminterface.c
 
 Function:
-	gk_McciBootloaderPlatformInterface for MCCI Catena 4801 boards.
+	gk_McciBootloaderPlatformInterface for MCCI Catena 491x boards.
 
 Copyright and License:
-	This file copyright (C) 2021 by
+	This file copyright (C) 2023 by
 
 		MCCI Corporation
 		3520 Krums Corners Road
@@ -15,7 +15,7 @@ Copyright and License:
 	See accompanying LICENSE file for copyright and license information.
 
 Author:
-	Terry Moore, MCCI Corporation	March 2021
+	Dhinesh Kumar Pitchai, MCCI Corporation	September 2023
 
 */
 

--- a/platform/board/mcci/model491x/src/mccibootloaderboard_model491x_platforminterface.c
+++ b/platform/board/mcci/model491x/src/mccibootloaderboard_model491x_platforminterface.c
@@ -1,0 +1,78 @@
+/*
+
+Module:	mccibootloaderboard_model491x_platforminterface.c
+
+Function:
+	gk_McciBootloaderPlatformInterface for MCCI Catena 4801 boards.
+
+Copyright and License:
+	This file copyright (C) 2021 by
+
+		MCCI Corporation
+		3520 Krums Corners Road
+		Ithaca, NY  14850
+
+	See accompanying LICENSE file for copyright and license information.
+
+Author:
+	Terry Moore, MCCI Corporation	March 2021
+
+*/
+
+#include "mcci_bootloader_board_model491x.h"
+
+#include "mcci_bootloader_flash_mx25v8035f.h"
+
+/****************************************************************************\
+|
+|	Manifest constants & typedefs.
+|
+\****************************************************************************/
+
+
+
+/****************************************************************************\
+|
+|	Read-only data.
+|
+\****************************************************************************/
+
+const McciBootloaderPlatform_Interface_t
+gk_McciBootloaderPlatformInterface =
+	{
+	.pSystemInit = McciBootloaderBoard_CatenaAbz_systemInit,
+	.pPrepareForLaunch = McciBootloaderBoard_CatenaAbz_prepareForLaunch,
+	.pFail = McciBootloaderBoard_CatenaAbz_fail,
+	.pDelayMs = McciBootloaderBoard_CatenaAbz_delayMs,
+	.pGetUpdate = McciBootloaderBoard_CatenaAbz_getUpdate,
+	.pSetUpdate = McciBootloaderBoard_CatenaAbz_setUpdate,
+	.pSystemFlashErase = McciBootloader_Stm32L0_systemFlashErase,
+	.pSystemFlashWrite = McciBootloader_Stm32L0_systemFlashWrite,
+	.Storage =
+		{
+		.pInit = McciBootloaderBoard_Model491x_storageInit,
+		.pRead = McciBootloaderFlash_Mx25v8035f_storageRead,
+		.pGetPrimaryAddress = McciBootloaderBoard_CatenaAbz_getPrimaryStorageAddress,
+		.pGetFallbackAddress = McciBootloaderBoard_CatenaAbz_getFallbackStorageAddress,
+		},
+	.Spi =
+		{
+		.pInit = McciBootloaderBoard_CatenaAbz_spiInit,
+		.pTransfer = McciBootloaderBoard_CatenaAbz_spiTransfer,
+		},
+	.Annunciator =
+		{
+		.pInit = McciBootloaderBoard_CatenaAbz_annunciatorInit,
+		.pIndicateState = McciBootloaderBoard_CatenaAbz_annunciatorIndicateState,
+		},
+	};
+
+/****************************************************************************\
+|
+|	Variables.
+|
+\****************************************************************************/
+
+
+
+/**** end of mccibootloaderboard_catenaabz_platforminterface.c ****/

--- a/platform/board/mcci/model491x/src/mccibootloaderboard_model491x_platforminterface.c
+++ b/platform/board/mcci/model491x/src/mccibootloaderboard_model491x_platforminterface.c
@@ -75,4 +75,4 @@ gk_McciBootloaderPlatformInterface =
 
 
 
-/**** end of mccibootloaderboard_catenaabz_platforminterface.c ****/
+/**** end of mccibootloaderboard_model491x_platforminterface.c ****/

--- a/platform/board/mcci/model491x/src/mccibootloaderboard_model491x_storageinit.c
+++ b/platform/board/mcci/model491x/src/mccibootloaderboard_model491x_storageinit.c
@@ -6,7 +6,7 @@ Function:
 	McciBootloaderBoard_Model491x_storageInit()
 
 Copyright and License:
-	This file copyright (C) 2021 by
+	This file copyright (C) 2023 by
 
 		MCCI Corporation
 		3520 Krums Corners Road
@@ -15,7 +15,7 @@ Copyright and License:
 	See accompanying LICENSE file for copyright and license information.
 
 Author:
-	Terry Moore, MCCI Corporation	March 2021
+	Dhinesh Kumar Pitchai, MCCI Corporation	September 2023
 
 */
 
@@ -60,7 +60,7 @@ storagePowerOn(void)
 		MCCI_STM32L0_REG_RCC_IOPENR_IOPHEN
 		);
 
-	// turn on power to the storage chip (4801) by making PH1 an output and
+	// turn on power to the storage chip (491x) by making PH1 an output and
 	// driving it to a one.
 	McciArm_putRegMasked(
 		MCCI_STM32L0_REG_GPIOH + MCCI_STM32L0_GPIO_MODER,

--- a/platform/board/mcci/model491x/src/mccibootloaderboard_model491x_storageinit.c
+++ b/platform/board/mcci/model491x/src/mccibootloaderboard_model491x_storageinit.c
@@ -1,0 +1,92 @@
+/*
+
+Module:	mccibootloaderboard_catena491x_storageinit.c
+
+Function:
+	McciBootloaderBoard_Model491x_storageInit()
+
+Copyright and License:
+	This file copyright (C) 2021 by
+
+		MCCI Corporation
+		3520 Krums Corners Road
+		Ithaca, NY  14850
+
+	See accompanying LICENSE file for copyright and license information.
+
+Author:
+	Terry Moore, MCCI Corporation	March 2021
+
+*/
+
+#include "mcci_bootloader_board_model491x.h"
+
+#include "mcci_bootloader_board_catena_abz.h"
+#include "mcci_bootloader_flash_mx25v8035f.h"
+#include "mcci_stm32l0xx.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/****************************************************************************\
+|
+|	Manifest constants & typedefs.
+|
+\****************************************************************************/
+
+static void
+storagePowerOn(void);
+
+/****************************************************************************\
+|
+|	Read-only data.
+|
+\****************************************************************************/
+
+
+
+/****************************************************************************\
+|
+|	Variables.
+|
+\****************************************************************************/
+
+static void
+storagePowerOn(void)
+	{
+	// enable GPIOH
+	McciArm_putRegOr(
+		MCCI_STM32L0_REG_RCC_IOPENR,
+		MCCI_STM32L0_REG_RCC_IOPENR_IOPHEN
+		);
+
+	// turn on power to the storage chip (4801) by making PH1 an output and
+	// driving it to a one.
+	McciArm_putRegMasked(
+		MCCI_STM32L0_REG_GPIOH + MCCI_STM32L0_GPIO_MODER,
+		MCCI_STM32L0_GPIO_MODE_P(1),
+		MCCI_BOOTLOADER_FIELD_SET_VALUE(MCCI_STM32L0_GPIO_MODE_P(1), MCCI_STM32L0_GPIO_MODE_OUT)
+		);
+
+	McciArm_putRegOr(
+		MCCI_STM32L0_REG_GPIOH + MCCI_STM32L0_GPIO_BSRR,
+		MCCI_STM32L0_GPIO_BSRR_BS_P(1)
+		);
+
+	// delay 50 ms
+	McciBootloaderPlatform_delayMs(50);
+	}
+
+
+void
+McciBootloaderBoard_Model491x_storageInit(
+	void
+	)
+	{
+	storagePowerOn();
+	McciBootloaderPlatform_spiInit();
+	McciBootloaderFlash_Mx25v8035f_storageInit();
+	}
+
+
+/**** end of mccibootloaderboard_model491x_storageinit.c ****/

--- a/platform/board/mcci/model491x/src/mccibootloaderboard_model491x_storageinit.c
+++ b/platform/board/mcci/model491x/src/mccibootloaderboard_model491x_storageinit.c
@@ -1,6 +1,6 @@
 /*
 
-Module:	mccibootloaderboard_catena491x_storageinit.c
+Module:	mccibootloaderboard_model491x_storageinit.c
 
 Function:
 	McciBootloaderBoard_Model491x_storageInit()

--- a/tools/mccibootloader_image/i/mccibootloader_image_version.h
+++ b/tools/mccibootloader_image/i/mccibootloader_image_version.h
@@ -27,7 +27,7 @@ Author:
 #include "mccibootloader_image.h"
 
 constexpr McciVersion::Version_t kVersion =
-	McciVersion::makeVersion(0, 4, 0, 0);
-constexpr char kCopyright[] = "Copyright (C) 2021, MCCI Corporation";
+	McciVersion::makeVersion(0, 5, 0, 0);
+constexpr char kCopyright[] = "Copyright (C) 2023, MCCI Corporation";
 
 #endif /* _mccibootloader_image_version_h_ */

--- a/tools/mccibootloader_image/i/mccibootloader_image_version.h
+++ b/tools/mccibootloader_image/i/mccibootloader_image_version.h
@@ -27,7 +27,7 @@ Author:
 #include "mccibootloader_image.h"
 
 constexpr McciVersion::Version_t kVersion =
-	McciVersion::makeVersion(0, 5, 0, 0);
-constexpr char kCopyright[] = "Copyright (C) 2023, MCCI Corporation";
+	McciVersion::makeVersion(0, 4, 0, 0);
+constexpr char kCopyright[] = "Copyright (C) 2021, MCCI Corporation";
 
 #endif /* _mccibootloader_image_version_h_ */


### PR DESCRIPTION
  **Board descriptions**

  - _Catena 51xx (e.g., Catena 5120):_ A Murata ABZ-based LoRa sensor board with onboard MX25R8035F SPI flash, FRAM, and environmental sensors. The flash chip
   is powered directly from +VDD — no switched power supply is involved.
  - _Model 491x (e.g., Model 4917):_ A Murata ABZ-based LoRa sensor board with onboard MX25R8035F SPI flash, FRAM, and a JST connector for external sensors.
  The flash chip is powered through a high-side switch (SLG59M1639V), controlled by PH1 (D10).

  **Hardware differences driving design choices**

  The Model 491x uses a dual high-side switch (SLG59M1639V) to gate power to the flash and FRAM via VOUT1. PH1 drives the ON1 enable pin, which defaults low
   (off) at power-on. The bootloader must drive PH1 high and wait 50ms before accessing flash. This storagePowerOn() sequence is cloned from the Catena
  4801, which uses the same PH1-controlled power switching design.

  The Catena 51xx connects flash VCC directly to +VDD, so flash is available as soon as the board powers up. No GPIO power-on step is needed. The
  storageInit simply calls spiInit() and flashInit(), matching the Catena 46xx approach.

  **GPIO verification**

  - _Model 4917:_ PH1 → ON1 on SLG59M1639V → VOUT1 → flash VCC, confirmed against Model 4917 Rev B schematic (234001499b) and
  https://github.com/mcci-catena/Arduino_Core_STM32/blob/main/variants/MODEL_4917/variant.h.
  - _Catena 5120:_ Flash VCC wired directly to +VDD, confirmed against Catena 5120 schematic (234001394a) and
  https://github.com/mcci-catena/Arduino_Core_STM32/blob/issue195/variants/CATENA_512x/variant.h.